### PR TITLE
Enable the Auto Hight Symbol feature after installation

### DIFF
--- a/AutoHighlightSymbol/AutoHighlightSymbol.m
+++ b/AutoHighlightSymbol/AutoHighlightSymbol.m
@@ -27,7 +27,11 @@ static NSString *const AHSHighlightColorKey = @"com.nelson.AutoHighlightSymbol.h
 }
 
 + (BOOL)isEnabled {
-  return [[NSUserDefaults standardUserDefaults] boolForKey:AHSEnabledKey];
+  NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
+  if ([[[prefs dictionaryRepresentation] allKeys] containsObject:AHSEnabledKey]) {
+    return [prefs boolForKey:AHSEnabledKey];
+  }
+  return YES;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
### Spec suggestion

After installing the extension, the feature in the `Editor` -> `Auto Hight Symbol` is not checked initially.
Set the default return value of `[AutoHighlightSymbol isEnabled]` to `YES` so the developer can enjoy this feature instantly after she installs this extension.
